### PR TITLE
This commit adds two things:

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ module.exports = function (source) {
             return;
         }
         cmd.get(`${compiler.name} ${compiler.switches} '${srcDir}${slash}${basename}.py'`, function(err, data, stderr) {
+
             if (!err) {
                 const filename = `${srcDir}${slash}${compiler.folder}${slash}${basename}.js`;
                 js = fs.readFileSync(filename, "utf8");
@@ -133,7 +134,8 @@ module.exports = function (source) {
 
             }
             else {
-                console.log(stderr)
+                console.error(stderr)
+                console.error(data)
                 // console.error(`Some error occurred on ${properName(compiler.name)} compiler execution. Have you installed ${properName(compiler.name)}? If not, please run \`${compiler.install}\` (requires Python ${compiler.python_version})`);
                 callback(err);
             }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const { sep: slash } = require('path');
 const path = require('path');
 const loaderUtils = require('loader-utils');
+const extend = require('extend');
 
 const spawn = require('child_process').spawn;
 
@@ -19,14 +20,16 @@ module.exports = function (source) {
             folder: `.${slash}__javascript__`,
             install: 'pip install transcrypt',
             python_version: '3.x',
-            sourcemaps: true
+            sourcemaps: true,
+            keep_compiled: false
         },
         jiphy: {
             switches: '',
             folder: `.${slash}`,
             install: 'pip install jiphy',
             python_version: '2.x',
-            sourcemaps: false
+            sourcemaps: false,
+            keep_compiled: false
         },
         pj: {
             switches: '--inline-map --source-name %f -s -',
@@ -34,13 +37,14 @@ module.exports = function (source) {
             install: 'pip install javascripthon',
             python_version: '3.x',
             streaming: true,
-            sourcemaps: true
+            sourcemaps: true,
+            keep_compiled: false
         }
     };
 
     const options = loaderUtils.getOptions(this);
     const compilerName = options && options.compiler || 'transcrypt';
-    const compiler = compilers[compilerName];
+    const compiler = extend(true, {}, compilers[compilerName], options || {});
 
     if (!compiler) {
         throw new Error(`py-loader only supports ${
@@ -108,16 +112,21 @@ module.exports = function (source) {
             if (!err) {
                 const filename = `${srcDir}${slash}${compiler.folder}${slash}${basename}.js`;
                 js = fs.readFileSync(filename, "utf8");
-                fs.unlinkSync(filename);
-                if(delete_after){
-                    fs.unlinkSync(`${srcDir}${slash}__${fileinfo.name}.py`);
+                if (!compiler.keep_compiled) {
+                    fs.unlinkSync(filename);
+                    if (delete_after) {
+                        fs.unlinkSync(`${srcDir}${slash}__${fileinfo.name}.py`);
+                    }
                 }
 
                 if (compiler.sourcemaps) {
                     const sourceMapFile = `${srcDir}${slash}${compiler.folder}${slash}extra${slash}sourcemap${slash}${basename}.js`;
                     sourceMap = fs.readFileSync(sourceMapFile + ".map", "utf8")
-                    fs.unlinkSync(sourceMapFile + ".map");
-                    callback(null, js, sourceMap); }
+                    if (!compiler.keep_compiled) {
+                        fs.unlinkSync(sourceMapFile + ".map");
+                    }
+                    callback(null, js, sourceMap);
+                }
                 else {
                     callback(null, js);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,11 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "index.js"
   ],
   "dependencies": {
+    "extend": "^3.0.1",
     "loader-utils": "^1.1.0",
     "node-cmd": "^3.0.0"
   },


### PR DESCRIPTION
1. All options can now be specified in the webpack.config.js file.
This means that things like python version, folder, sourcemaps, etc.
can be overridden when needed.  In particular, being able to modify
the switches is useful.

2. A new option `keep_compiled` keeps the compiled files instead
of unlinking (deleting) them.  The default of this new switch
is the behavior of the module previously.

None of these changes require anything to be done to the config
files in projects already using the module.  Fully backwards-compatible.